### PR TITLE
build both x64 and arm64 for mac

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@terminalone/monorepo",
   "productName": "Terminal One",
-  "version": "1.3.1",
+  "version": "1.4.0",
   "description": "A fast, elegant and intelligent cross-platform terminal.",
   "author": "atinylittleshell <shell@atinylittleshell.me>",
   "license": "MIT",
@@ -45,7 +45,7 @@
   "build": {
     "appId": "io.terminalone.app",
     "productName": "Terminal One",
-    "artifactName": "TerminalOne-${version}.${ext}",
+    "artifactName": "TerminalOne-${version}-${arch}.${ext}",
     "extends": null,
     "files": [
       "apps/app/dist/**/*"
@@ -58,6 +58,15 @@
       "category": "Development",
       "target": "AppImage",
       "icon": "icon.icns"
+    },
+    "mac": {
+      "target": {
+        "target": "dmg",
+        "arch": [
+          "arm64",
+          "x64"
+        ]
+      }
     }
   },
   "devDependencies": {


### PR DESCRIPTION
This will allow us to release both an x64 and arm64 build for mac. May help with https://github.com/atinylittleshell/TerminalOne/issues/37 and https://github.com/atinylittleshell/TerminalOne/issues/36