### PR TITLE
default to .config/TerminalOne/config.js as the config path

### DIFF
--- a/apps/app/src/nativeBridge/modules/common/index.ts
+++ b/apps/app/src/nativeBridge/modules/common/index.ts
@@ -3,5 +3,6 @@ import { app } from 'electron';
 export const getAppDirs = () => {
   return {
     userData: app.getPath('userData'),
+    home: app.getPath('home'),
   };
 };

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@terminalone/monorepo",
   "productName": "Terminal One",
-  "version": "1.5.1",
+  "version": "1.6.0",
   "description": "A fast, elegant and intelligent cross-platform terminal.",
   "author": "atinylittleshell <shell@atinylittleshell.me>",
   "license": "MIT",


### PR DESCRIPTION
addressing https://github.com/atinylittleshell/TerminalOne/issues/32

default config path now becomes ~/.config/TerminalOne/config.js 

for backward compatibility we will still use the previous config path if that exists. users who prefer the new default path can manually migrate