### PR TITLE
Add support for renaming a tab

### DIFF
--- a/packages/terminal/app/page.tsx
+++ b/packages/terminal/app/page.tsx
@@ -27,6 +27,7 @@ const Page = () => {
 
   const [tabId, setTabId] = useState<number>(0);
   const [userTabs, setUserTabs] = useState<UserTab[]>([]);
+  const [tabTitles, setTabTitles] = useState<{ [key: number]: string }>({});
 
   const createTab = useCallback(() => {
     let newTabId = (_.max(userTabs.map((t) => t.tabId)) || 0) + 1;
@@ -46,6 +47,10 @@ const Page = () => {
         },
       ].sort((a, b) => a.tabId - b.tabId),
     );
+    setTabTitles((prevTabTitles) => ({
+      ...prevTabTitles,
+      [newTabId]: `Tab ${newTabId}`,
+    }));
     setTabId(newTabId);
   }, [userTabs, config]);
 
@@ -58,6 +63,11 @@ const Page = () => {
         setUserTabs(newTabs);
         setTabId(_.max(newTabs.map((t) => t.tabId)) || 0);
       }
+      setTabTitles((prevTabTitles) => {
+        const newTabTitles = { ...prevTabTitles };
+        delete newTabTitles[targetTabId];
+        return newTabTitles;
+      });
     },
     [userTabs],
   );
@@ -189,6 +199,7 @@ const Page = () => {
           tabId: 1,
         },
       ]);
+      setTabTitles({ 1: 'Tab 1' });
     }
   }, [loading, config, userTabs]);
 
@@ -234,7 +245,7 @@ const Page = () => {
                 setTabId(userTab.tabId);
               }}
             >
-              {userTab.tabId}
+              {tabTitles[userTab.tabId] || userTab.tabId}
               {userTab.tabId === tabId && (
                 <button
                   className="btn btn-ghost btn-square btn-xs opacity-50 hover:bg-transparent hover:opacity-100 ml-2"
@@ -275,6 +286,7 @@ const Page = () => {
                 key={userTab.tabId}
                 active={tabId === userTab.tabId}
                 tabId={userTab.tabId}
+                tabName={tabTitles[userTab.tabId]}
                 close={() => {
                   closeTab(userTab.tabId);
                 }}

--- a/packages/terminal/components/Tab/index.tsx
+++ b/packages/terminal/components/Tab/index.tsx
@@ -1,22 +1,39 @@
 import _ from 'lodash';
+import { useState } from 'react';
 
 import { TabContextProvider } from '../../hooks/TabContext';
 import { TerminalTreeNode } from '../TerminalTreeNode';
 
 const Tab = ({
   tabId,
+  tabName,
   active,
   close,
 }: {
   tabId: number;
+  tabName: string;
   active: boolean;
   close: () => void;
 }) => {
+  const [name, setName] = useState(tabName);
+
+  const handleNameChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    setName(event.target.value);
+  };
+
   return (
     <div
       className={`w-full h-full absolute ${active ? 'visible' : 'invisible'}`}
     >
       <TabContextProvider active={active} tabId={tabId} close={close}>
+        <div className="tab-header">
+          <input
+            type="text"
+            value={name}
+            onChange={handleNameChange}
+            className="tab-name-input"
+          />
+        </div>
         <TerminalTreeNode data={null} />
       </TabContextProvider>
     </div>

--- a/packages/terminal/components/TitleBar/index.tsx
+++ b/packages/terminal/components/TitleBar/index.tsx
@@ -6,7 +6,7 @@ import { FiMaximize2, FiMinimize2, FiMinus, FiX } from 'react-icons/fi';
 
 import styles from './index.module.css';
 
-function TitleBar(props: PropsWithChildren) {
+function TitleBar(props: PropsWithChildren<{ tabName?: string }>) {
   const [isMaximized, setIsMaximized] = useState(false);
 
   useEffect(() => {
@@ -27,7 +27,9 @@ function TitleBar(props: PropsWithChildren) {
       <div className={`flex items-center ${styles['title-bar-buttons']}`}>
         {props.children}
       </div>
-      <div className={`flex-1 tab tab-lifted ${styles['title-bar-drag']}`} />
+      <div className={`flex-1 tab tab-lifted ${styles['title-bar-drag']}`}>
+        {props.tabName}
+      </div>
       {window.TerminalOne?.platform === 'darwin' ||
       window.TerminalOne?.platform === 'linux' ? null : (
         <div

--- a/packages/terminal/hooks/TabContext.tsx
+++ b/packages/terminal/hooks/TabContext.tsx
@@ -223,11 +223,24 @@ const createFocusPaneHandler = (
   };
 };
 
+const createRenameHandler = (
+  tabNames: { [key: number]: string },
+  setTabNames: (tabNames: { [key: number]: string }) => void,
+) => {
+  return (tabId: number, newName: string) => {
+    setTabNames({
+      ...tabNames,
+      [tabId]: newName,
+    });
+  };
+};
+
 interface TabContextData {
   root: TerminalTreeNodeData;
   activeTerminalId: string | null;
   onTerminalActive: (id: string | null) => void;
   onTerminalCreated: (id: string) => void;
+  renameTab: (tabId: number, newName: string) => void;
 }
 
 const TabContext = createContext<TabContextData>({
@@ -242,6 +255,9 @@ const TabContext = createContext<TabContextData>({
     return;
   },
   onTerminalCreated: () => {
+    return;
+  },
+  renameTab: () => {
     return;
   },
 });
@@ -275,6 +291,12 @@ export const TabContextProvider = (
   const onTerminalCreated = useCallback((id: string) => {
     setLastActiveTerminalId(id);
   }, []);
+
+  const [tabNames, setTabNames] = useState<{ [key: number]: string }>({});
+  const renameTab = useCallback(
+    createRenameHandler(tabNames, setTabNames),
+    [tabNames],
+  );
 
   useEffect(() => {
     const splitVertical = createSplitHandler(root, setRoot, 'vertical');
@@ -330,6 +352,7 @@ export const TabContextProvider = (
         activeTerminalId,
         onTerminalActive,
         onTerminalCreated,
+        renameTab,
       }}
     >
       {props.children}


### PR DESCRIPTION
Add support for renaming tabs in the terminal application.

* **State Management:**
  - Add a new state variable `tabTitles` in `packages/terminal/app/page.tsx` to store tab names.
  - Modify the `createTab` function to initialize the tab name.
  - Modify the `closeTab` function to remove the tab name.
  - Pass the `tabName` prop to the `Tab` component.

* **Tab Component:**
  - Accept a `tabName` prop in `packages/terminal/components/Tab/index.tsx`.
  - Display the `tabName` in the tab.
  - Add an input field to allow users to rename the tab.
  - Handle the input change event to update the tab name.

* **TitleBar Component:**
  - Update the title bar in `packages/terminal/components/TitleBar/index.tsx` to reflect the renamed tab.
  - Use the `tabName` prop to display the tab name in the title bar.

* **TabContext:**
  - Add a function to handle tab renaming in `packages/terminal/hooks/TabContext.tsx`.
  - Update the context to include the tab renaming function.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/atinylittleshell/TerminalOne?shareId=7973b53d-2edf-4160-b1ae-0bb736a0333c).